### PR TITLE
Fixes bug for empty thesaurus

### DIFF
--- a/ckanext/ioos_theme/templates/package/snippets/meta_keywords.html
+++ b/ckanext/ioos_theme/templates/package/snippets/meta_keywords.html
@@ -18,7 +18,7 @@ Example:
         </td>
         <td width="70%">
           {% for keyword_dict in keywords %}
-            {% if keyword_dict['thesaurus']['title'] %}
+            {% if keyword_dict['thesaurus'] and keyword_dict['thesaurus']['title'] %}
               {{ keyword_dict['thesaurus']['title'] }}
             {% else %}
               Uncategorized


### PR DESCRIPTION
If the title of a thesaurus is empty, the UI used to show
"builtin-method title for..." instead of "Uncategorized" like it should.
This commit fixes the bug.

Resolves #74 