### PR TITLE
Adds better attribution

### DIFF
--- a/ckanext/ioos_theme/plugin.py
+++ b/ckanext/ioos_theme/plugin.py
@@ -39,6 +39,38 @@ def get_point_of_contact(pkg):
     return pocs
 
 
+def get_role_code(role):
+    '''
+    Returns the Human Readable version of the role from the ISOTC211/19115 role
+    list.
+
+    :param str role: Role
+    '''
+    if role == 'resourceProvider':
+        return 'Resource Provider'
+    if role == 'custodian':
+        return 'Custodian'
+    if role == 'owner':
+        return 'Owner'
+    if role == 'user':
+        return 'User'
+    if role == 'distributor':
+        return 'Distributor'
+    if role == 'originator':
+        return 'Originator'
+    if role == 'pointOfContact':
+        return 'Point of Contact'
+    if role == 'principalInvestigator':
+        return 'Principal Investigator'
+    if role == 'processor':
+        return 'Processor'
+    if role == 'publisher':
+        return 'Publisher'
+    if role == 'author':
+        return 'Author'
+    return role
+
+
 def get_responsible_organization(pkg):
     responsible_organization = next((extra['value'] for extra in pkg['extras'] if extra['key'] == 'responsible-organisation'))
     return json.loads(responsible_organization)
@@ -63,7 +95,7 @@ def get_distribution_formats(pkg):
             continue
         name = distributor['data-format'].get('name', None)
         version = distributor['data-format'].get('version', None)
-        if name is None:
+        if not name:
             continue
         retval.append({
             "name": name,
@@ -78,7 +110,7 @@ def get_distribution_formats(pkg):
             continue
         name = dist_format.get('name', None)
         version = dist_format.get('version', None)
-        if name is None:
+        if not name:
             continue
         retval.append({
             "name": name,
@@ -143,5 +175,6 @@ class Ioos_ThemePlugin(plugins.SingletonPlugin):
             "ioos_theme_get_pkg_item": get_pkg_item,
             "ioos_theme_get_pkg_extra": get_pkg_extra,
             "ioos_theme_get_pkg_ordereddict": get_pkg_ordereddict,
-            "ioos_theme_jsonpath": jsonpath
+            "ioos_theme_jsonpath": jsonpath,
+            "ioos_theme_get_role_code": get_role_code,
         }

--- a/ckanext/ioos_theme/templates/package/snippets/access/responsible_parties.html
+++ b/ckanext/ioos_theme/templates/package/snippets/access/responsible_parties.html
@@ -1,0 +1,41 @@
+{# 
+pkg - A package object that the resources belong to.
+
+Example:
+
+  {% snippet "package/snippets/access/responsible_parties.html", pkg=pkg, resources=pkg.resources %}
+
+#}
+{% for responsible_party in h.ioos_theme_get_pkg_item(pkg, "responsible-parties") %}
+<tr>
+  <td>
+    {{ h.ioos_theme_get_role_code(responsible_party.role) }}
+  </td>
+  <td>
+    {% if responsible_party['individual-name'] %}
+      {{ responsible_party['individual-name'] }}<br>
+    {% endif %}
+    {% if responsible_party['organisation-name'] %}
+      {{ responsible_party['organisation-name'] }}<br>
+    {% endif %}
+    {% if responsible_party['contact-info']['email'] %}
+    <a href="mailto:{{responsible_party['contact-info']['email']}}">
+      {{ responsible_party['contact-info']['email'] }}
+    </a><br>
+    {% endif %}
+    {% if responsible_party['contact-info']['phone'] %}
+      {{ responsible_party['contact-info']['phone'] }}<br>
+    {% endif %}
+    {% if responsible_party['contact-info']['online-resource'] %}
+    {% set link = responsible_party['contact-info']['online-resource'] %}
+      <a href="{{link.url}}">
+        {{link.name}}
+        {% if link.description %}
+         <i>({{link.description}})</i>
+         {% endif %}
+      </a>
+    {% endif %}
+  </td>
+</tr>
+{% endfor %}
+

--- a/ckanext/ioos_theme/templates/package/snippets/meta_access.html
+++ b/ckanext/ioos_theme/templates/package/snippets/meta_access.html
@@ -48,6 +48,9 @@ Example:
       </td>
     </tr>
     {% endif %}
+    {% if h.ioos_theme_get_pkg_item(pkg, "responsible-parties") %}
+    {% snippet "package/snippets/access/responsible_parties.html", pkg=pkg %}
+    {% endif %}
     <tr>
       <td>
         Dataset Point of Contact
@@ -66,7 +69,9 @@ Example:
               {{ contact.phone.voice }}<br>
             {% endif %}
             {% if contact.email %}
+            <a href="mailto:{{contact.email}}">
               {{ contact.email }}
+            </a>
             {% endif %}
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
The Access tab got a small refactor. Each entry found within an ISO
defining CI_Responsible_Party should have a row in the table for Access.
The ISOTC211/19115 Roles are mapped to human readable versions and the
contents for the responsible party are rendered. URLs are mapped to HTML
Anchors. Emails are mapped to Anchors with `mailto` defined as the email
address.

I also added some code that cleans up edge cases where required tags
aren't filled in like names for URLs.