### PR TITLE
Fixes config bug

### DIFF
--- a/ckanext/ioos_theme/plugin.py
+++ b/ckanext/ioos_theme/plugin.py
@@ -229,7 +229,6 @@ class Ioos_ThemePlugin(plugins.SingletonPlugin):
         '''
         schema.update({
             'feedback.recipients': [unicode],
-            'smtp.port': [int_validator],
-            'ckan.ioos_theme.pycsw_config': [unicode],
+            'smtp.port': [int_validator]
         })
         return schema


### PR DESCRIPTION
When a plugin extends the update_config_schema method, these apply to
configration schema definitions for the UI's Admin Controller, not the
application as a whole. So when ckan.ioos_theme.pycsw_config was defined
in here, administrator's couldn't save the config form page because
there wasn't a form for the config file.