### PR TITLE
Redirect to package on package feedback after submit

### DIFF
--- a/ckanext/ioos_theme/controllers/feedback.py
+++ b/ckanext/ioos_theme/controllers/feedback.py
@@ -34,14 +34,15 @@ class FeedbackController(BaseController):
         errors = errors or {}
         error_summary = error_summary or {}
         vars = {
-            'ds_id': None,
+            'package_name': None,
             'data': data,
             'errors': errors,
             'error_summary': error_summary
         }
         return render('feedback/form.html', extra_vars=vars)
 
-    def dataset_id(self, ds_id=None, data=None, errors=None, error_summary=None):
+    def feedback_package(self, package_name=None, data=None, errors=None,
+                         error_summary=None):
         '''
         Returns a render for the feedback form.
 
@@ -58,7 +59,7 @@ class FeedbackController(BaseController):
         errors = errors or {}
         error_summary = error_summary or {}
         vars = {
-            'ds_id': ds_id,
+            'package_name': package_name,
             'data': data,
             'errors': errors,
             'error_summary': error_summary
@@ -74,7 +75,7 @@ class FeedbackController(BaseController):
             'name': request.params['name'],
             'email': request.params['email'],
             'feedback': request.params['feedback'],
-            'dataset_id': request.params.get('dataset-id')
+            'package_name': request.params.get('package_name')
         }
         feedback.send_feedback(context)
         h.flash_notice(_('Thank you for your feedback'))

--- a/ckanext/ioos_theme/plugin.py
+++ b/ckanext/ioos_theme/plugin.py
@@ -172,7 +172,7 @@ class Ioos_ThemePlugin(plugins.SingletonPlugin):
 
     def update_config(self, config_):
         '''
-        Extends the templates directory and adds fanstatic. 
+        Extends the templates directory and adds fanstatic.
 
         :param config_: Passed from CKAN framework
         '''
@@ -202,7 +202,7 @@ class Ioos_ThemePlugin(plugins.SingletonPlugin):
         Defines routes for feedback and overrides routes for the admin controller
         '''
         controller = 'ckanext.ioos_theme.controllers.feedback:FeedbackController'
-        map.connect('feedback_dataset', '/feedback/{ds_id}', controller=controller, action='dataset_id')
+        map.connect('feedback_package', '/feedback/{package_name}', controller=controller, action='feedback_package')
         map.connect('feedback', '/feedback', controller=controller, action='index')
 
         admin_controller = 'ckanext.ioos_theme.controllers.admin:IOOSAdminController'

--- a/ckanext/ioos_theme/templates/feedback/form.html
+++ b/ckanext/ioos_theme/templates/feedback/form.html
@@ -10,18 +10,24 @@
   <article class="module">
     <div class="module-content">
       {% block primary_content_inner %}
-      {# can't seem to get this from extra_vars #}
-      <h1 class="page-heading">{{ _('Submit Feedback')}}{% if c.ds_id is defined %} for Dataset ID {{c.ds_id}}{% endif %}</h1>
+      {# Appears to coerce to empty string? Can the check for package_name
+         be simplified? #}
+      <h1 class="page-heading">{{ _('Submit Feedback')}}{% if c.package_name is not none and c.package_name != '' %} for Dataset ID {{c.package_name}}{% endif %}</h1>
       {% block form %}
-
-      <form id="user-register-form" class="form-horizontal" action="" method="post">
+        {% if c.package_name is not none and c.package_name != '' %}
+          {% set action_loc = h.url_for(controller='package', action='read', id=c.package_name) %}
+        {% else %}
+          {% set action_loc = "" %}
+        {% endif %}
+      <form id="user-register-form" class="form-horizontal" method="post"
+          action="{{ action_loc }}">
         {{ form.errors(error_summary) }}
         {{ form.input("name", id="field-name", label=_("Name"), placeholder=_("Your name"), value=data.name, error=errors.name, classes=["control-medium"]) }}
         {{ form.input("email", id="field-email", label=_("Email"), type="email", placeholder=_("joe@example.com"), value=data.email, error=errors.email, classes=["control-medium"]) }}
         {{ form.textarea("feedback", id="field-feedback", label=_("Feedback"), placeholder=_("Your comments"), value=data.feedback, error=errors.feedback, classes=["control-medium"]) }}
-	{% if c.ds_id is defined %}
-        {{ form.hidden("dataset-id", value=c.ds_id) }}
-        {% endif %}
+     {% if c.package_name is not none and c.package_name != '' %}
+        {{ form.hidden("dataset-id", value=c.package_name) }}
+     {% endif %}
 
         <div class="form-actions">
           {% block form_actions %}

--- a/ckanext/ioos_theme/templates/package/read_base.html
+++ b/ckanext/ioos_theme/templates/package/read_base.html
@@ -11,7 +11,7 @@
 
 {% block content_action %}
   {# NB: link_for appears to be replaced by nav_link in newer versions of CKAN #}
-  {% link_for _('Feedback'), named_route='feedback_dataset', ds_id=pkg.name, class_='btn', icon='comment' %}
+  {% link_for _('Feedback'), named_route='feedback_package', package_name=pkg.name, class_='btn', icon='comment' %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
     {% link_for _('Manage'), controller='package', action='edit', id=pkg.name, class_='btn', icon='wrench' %}
   {% endif %}


### PR DESCRIPTION
Redirects to the package/dataset page upon submitting feedback.  Also
renames some routes to keep more consistent with CKAN's nomenclature.