### PR TITLE
LHS feedback button routing

### DIFF
--- a/ckanext/ioos_theme/templates/base.html
+++ b/ckanext/ioos_theme/templates/base.html
@@ -6,5 +6,7 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto+Slab" rel="stylesheet"> 
   <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"> 
 
-  <a id="feedback" class="hidden-xs" href='/feedback'></a>
+  {# populate dataset name for feedback when we are on a dataset page #}
+  {% set opt_pkg = pkg.name if pkg is defined else "" %}
+  <a id="feedback" class="hidden-xs" href="/feedback/{{opt_pkg}}"></a>
 {% endblock %}


### PR DESCRIPTION
Reroutes to a package feedback form when selecting the red feedback button on the left hand side of the site from a dataset information page.