### PR TITLE
Fix mobile view feedback button, upgrade to Recaptcha V3 testing

### DIFF
--- a/ckanext/ioos_theme/templates/base.html
+++ b/ckanext/ioos_theme/templates/base.html
@@ -8,5 +8,5 @@
 
   {# populate dataset name for feedback when we are on a dataset page #}
   {% set opt_pkg = pkg.name if pkg is defined else "" %}
-  <a id="feedback" class="hidden-xs" href="/feedback/{{opt_pkg}}"></a>
+  <a id="feedback" href="/feedback/{{opt_pkg}}"></a>
 {% endblock %}

--- a/ckanext/ioos_theme/templates/feedback/form.html
+++ b/ckanext/ioos_theme/templates/feedback/form.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block primary_content %}
-<!-- Google recaptcha api -->
-<script src='https://www.google.com/recaptcha/api.js'></script>
+
 
   <article class="module">
     <div class="module-content">
@@ -27,9 +26,32 @@
         {{ form.hidden("package_name", value=c.package_name) }}
      {% endif %}
 
+        <!-- Make name, email and feedback required fields -->
+        <script>
+        document.querySelector("#field-name").required = true;
+        document.querySelector("#field-email").required = true;
+        document.querySelector("#field-feedback").required = true;
+        </script>
+
+        <!-- Google Recaptcha V3 -->
+        <script src="https://www.google.com/recaptcha/api.js?render={{feedback_site_key}}"></script>
+        <script>
+        grecaptcha.ready(function() {
+            grecaptcha.execute('{{feedback_site_key}}', {action: 'homepage'}).then(function(token) {
+              var input = document.createElement("input");
+              input.setAttribute("value", token);
+              input.setAttribute("type", "hidden");
+              input.setAttribute("name", "g-captcha-token");
+              document.querySelector("#user-register-form").appendChild(input);
+            });
+        });
+        </script>
+
         <div class="form-actions">
           {% block form_actions %}
-          <div class="g-recaptcha" data-sitekey={{feedback_site_key}}></div>
+          <!-- Google Recaptcha V2 api  Left for reference -->
+          <!-- <div class="g-recaptcha" data-sitekey={{feedback_site_key}}></div> -->
+
           <button class="btn btn-primary" type="submit" name="submit">{{ _("Submit") }}</button>
           {% endblock %}
         </div>

--- a/ckanext/ioos_theme/templates/header.html
+++ b/ckanext/ioos_theme/templates/header.html
@@ -7,7 +7,6 @@
         {{ h.build_nav_main(
           ('search', _('Datasets')),
           ('organizations_index', _('Organizations')),
-          ('feedback', _('Feedback')),
           ('about', _('About'))
         ) }}
       {% endblock %}


### PR DESCRIPTION
Do not merge yet, posting this up to get some feedback.

This puts captcha via small slide out box on bottom right. So no need to check box, it uses V3 which doesn't require a check box. It only displays puzzle if it detects suspicious activity. 

I also fixed mobile view so it displays red feedback button even on small screens and I removed button on top menu.

I was having issues testing the submission of form using local smtp server but I was having same issue on master. 
@benjwadams Can you take a look at this and offer any suggestions/feedback.

If V3 doesn't look like the way to go, V2 with the "I'm not a robot" checkbox can be set to lower security settings which would not show puzzle as often. There is no way around not showing puzzle at all though, through my research. 