### PR TITLE
Fixes override of dcat-related templates

### DIFF
--- a/ckanext/ioos_theme/templates/admin/base.html
+++ b/ckanext/ioos_theme/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% extends "page.html" %}
+{% ckan_extends %}
 
 {% block subtitle %}{{ _('Administration') }}{% endblock %}
 

--- a/ckanext/ioos_theme/templates/home/index.html
+++ b/ckanext/ioos_theme/templates/home/index.html
@@ -1,4 +1,4 @@
-{% extends "page.html" %}
+{% ckan_extends %}
 {% set homepage_style = '3' %}
 
 {% block subtitle %}{{ _("Welcome") }}{% endblock %}

--- a/ckanext/ioos_theme/templates/package/read.html
+++ b/ckanext/ioos_theme/templates/package/read.html
@@ -1,4 +1,4 @@
-{% extends "package/read_base.html" %}
+{% ckan_extends %}
 
 {% set pkg = c.pkg_dict %}
 

--- a/ckanext/ioos_theme/templates/package/read_base.html
+++ b/ckanext/ioos_theme/templates/package/read_base.html
@@ -1,4 +1,4 @@
-{% extends "package/base.html" %}
+{% ckan_extends %}
 
 {% block subtitle %}{{ pkg.title or pkg.name }} - {{ super() }}{% endblock %}
 


### PR DESCRIPTION
Uses `ckan_extends` jinja2/CKAN template helper to restore
dcat/schema.org functionality.  Addresses #160.