### PR TITLE
Split GCMD keywords into separate tags

### DIFF
--- a/ckanext/ioos_theme/plugin.py
+++ b/ckanext/ioos_theme/plugin.py
@@ -211,6 +211,21 @@ def jsonpath(obj, path):
         log.info("OBJ: %s", obj)
     return obj
 
+def split_gcmd_tags(tags):
+    """
+    Splits any GCMD keyword components (usually separated by " > " into
+    separate, unique tags. Returns a list of tags if successful, or None
+    if the tags ran into an exception
+    """
+    #TODO: should we also store the full GCMD keywords as extras and in
+    #           Solr?
+    try:
+        unique_tags = set(chain(*[re.split(r'\s*>\s*', t.strip()) for t
+                                    in tags]))
+        return [{'name': val} for val in sorted(unique_tags)]
+    except:
+        log.exception("Error occurred while splitting GCMD tags:")
+        return None
 
 class Ioos_ThemePlugin(p.SingletonPlugin):
     '''
@@ -387,17 +402,9 @@ class Ioos_ThemePlugin(p.SingletonPlugin):
         package_dict = data_dict['package_dict']
         iso_values = data_dict['iso_values']
 
-        # split any GCMD keyword components (usually separated by " > " into
-        # separate, unique tags
-        # TODO: should we also store the full GCMD keywords as extras and in
-        #       Solr?
-        try:
-            unique_tags = set(chain(*[re.split(r'\s*>\s*', t.strip()) for t
-                                      in iso_values['tags']]))
-            package_dict['tags'] = [{'name': val} for val in
-                                    sorted(unique_tags)]
-        except:
-            log.exception("Error occurred while splitting GCMD tags:")
+        returned_tags =  split_gcmd_tags(iso_values['tags'])
+        if returned_tags is not None:
+            package_dict['tags'] = returned_tags
 
         # ckanext-dcat uses temporal_start and temporal_end for time extents
         # instead of temporal-extent-begin and temporal-extent-end as used by

--- a/ckanext/ioos_theme/plugin.py
+++ b/ckanext/ioos_theme/plugin.py
@@ -18,6 +18,8 @@ import copy
 import pendulum
 import datetime
 import six
+from itertools import chain
+import re
 from six.moves import urllib
 
 log = logging.getLogger(__name__)
@@ -384,6 +386,18 @@ class Ioos_ThemePlugin(p.SingletonPlugin):
 
         package_dict = data_dict['package_dict']
         iso_values = data_dict['iso_values']
+
+        # split any GCMD keyword components (usually separated by " > " into
+        # separate, unique tags
+        # TODO: should we also store the full GCMD keywords as extras and in
+        #       Solr?
+        try:
+            unique_tags = set(chain(*[re.split(r'\s*>\s*', t.strip()) for t
+                                      in iso_values['tags']]))
+            package_dict['tags'] = [{'name': val} for val in
+                                    sorted(unique_tags)]
+        except:
+            log.exception("Error occurred while splitting GCMD tags:")
 
         # ckanext-dcat uses temporal_start and temporal_end for time extents
         # instead of temporal-extent-begin and temporal-extent-end as used by

--- a/ckanext/ioos_theme/tests/test_plugin.py
+++ b/ckanext/ioos_theme/tests/test_plugin.py
@@ -1,5 +1,26 @@
 """Tests for plugin.py."""
+from unittest import TestCase
 import ckanext.ioos_theme.plugin as plugin
 
-def test_plugin():
-    pass
+
+class TestIOOSPlugin(TestCase):
+
+    def test_split_gcmd_tags(self):
+        """
+        Checks that GCMD separators are split and leading/ending whitespace
+        is removed from keywords.
+        """
+        test_kws = ['OCEANS > OCEAN TEMPERATURE > OCEAN MIXED LAYER',
+                    'OCEANS > SALINITY/DENSITY > CONDUCTIVITY',
+                    'OCEANS > OCEAN TEMPERATURE > THERMOCLINE',
+                    'OCEANS > SALINITY/DENSITY > PYCNOCLINE']
+        expected = [{'name': kw} for kw in
+                    sorted(['OCEANS', 'OCEAN TEMPERATURE', 'OCEAN MIXED LAYER',
+                                                           'THERMOCLINE',
+                                      'SALINITY/DENSITY',  'CONDUCTIVITY',
+                                                           'PYCNOCLINE'])]
+        self.assertEqual(plugin.split_gcmd_tags(test_kws), expected)
+        # test simple cases
+        expected = [{'name': 'oceans'}]
+        self.assertEqual(plugin.split_gcmd_tags([' oceans ']), expected)
+        self.assertEqual(plugin.split_gcmd_tags(['oceans']), expected)


### PR DESCRIPTION
Splits any GCMD keywords as determined by ">" surrounded by optional
spaces into separate tags.  Part of #172.