### PR TITLE
Exclude GCMD keywords and CF standard names from DS tags

### DIFF
--- a/ckanext/ioos_theme/templates/package/snippets/tags.html
+++ b/ckanext/ioos_theme/templates/package/snippets/tags.html
@@ -1,0 +1,13 @@
+{% if tags %}
+  {# TODO: Use Jinja2 2.10+ namespace() feature to keep variables accessible
+           within inner scopes after upgrading Jinja2 version, or rework call
+           to package controller #}
+  {% set cf_standard_names = h.ioos_theme_get_pkg_item(c.pkg_dict,
+                                                       "cf_standard_names") %}
+  {% set gcmd_keywords = h.ioos_theme_get_pkg_item(c.pkg_dict,
+                                                   "gcmd_keywords") %}
+  {% set tags_filt = h.filter_tag_names(tags, cf_standard_names, gcmd_keywords) %}
+  <section class="tags">
+    {% snippet 'snippets/tag_list.html', tags=tags_filt, _class='tag-list well' %}
+  </section>
+{% endif %}

--- a/ckanext/ioos_theme/tests/test_plugin.py
+++ b/ckanext/ioos_theme/tests/test_plugin.py
@@ -24,3 +24,40 @@ class TestIOOSPlugin(TestCase):
         expected = [{'name': 'oceans'}]
         self.assertEqual(plugin.split_gcmd_tags([' oceans ']), expected)
         self.assertEqual(plugin.split_gcmd_tags(['oceans']), expected)
+
+    def test_filter_tag_names(self):
+        gcmd_kws = ['OCEANS > OCEAN TEMPERATURE > OCEAN MIXED LAYER',
+                    'OCEANS > SALINITY/DENSITY > CONDUCTIVITY',
+                    'OCEANS  > OCEAN TEMPERATURE > THERMOCLINE',
+                    'OCEANS > SALINITY/DENSITY > PYCNOCLINE']
+
+        cf_standard_names = ['sea_water_temperature',
+                             'sea_water_electrical_conductivity',
+                             'sea_water_density']
+
+        def generate_tag_dict(name):
+            return {'vocabulary_id': None, 'state': 'active',
+                    'display_name': name, 'name': name,
+                    'id': None # would not normally be None, but needs to be invariant
+                   }
+
+        other_tags = ['Glider', 'AUV', 'oceans']
+        # freeform tags get GCMD keywords returned split up -- replicate this
+        # behavior
+        split_gcmd = list(plugin.split_gcmd_list(gcmd_kws))
+        all_tags = [generate_tag_dict(name) for name in
+                    split_gcmd + cf_standard_names + other_tags]
+        # don't pass in CF standard names and GCMD KWs - the result should be
+        # the same as the sorted list of all tags
+        expected_tags_no_filter = [generate_tag_dict(name) for name in
+				   set(split_gcmd + cf_standard_names +
+                                       other_tags)]
+        self.assertEqual(sorted(expected_tags_no_filter,
+                                key=lambda d: d['display_name']),
+                         plugin.filter_tag_names(all_tags, [], []))
+
+        # now pass in the CF standard names and GCMD keywords.  "oceans"
+        # should also be filtered out after splitting GCMD keywords
+        self.assertEqual([generate_tag_dict(t) for t in ['AUV', 'Glider']],
+                          plugin.filter_tag_names(all_tags, cf_standard_names,
+                                                  gcmd_kws))


### PR DESCRIPTION
Prevents GCMD keywords and CF standard names from appearing on "Freeform Tags" (tags field) on individual dataset detail pages.
Implements #209.