### PR TITLE
API about page faceting updates

### DIFF
--- a/ckanext/ioos_theme/templates/home/snippets/about_text.html
+++ b/ckanext/ioos_theme/templates/home/snippets/about_text.html
@@ -86,8 +86,9 @@
 <p>
 Yes.  Under the hood, CKAN uses Solr for search, and can accept Solr query strings in either the dataset search on the website or the
 <code><a href="https://docs.ckan.org/en/2.8/api/#ckan.logic.action.get.package_search">package_search</a></code> CKAN API endpoint.
-CF Standard Names are primarily provided by the `extras_cf_standard_names` field.  An example query is below:
-<a href='https://data.ioos.us/dataset?q=extras_cf_standard_names:"sea_water_pressure"'>https://data.ioos.us/dataset?q=extras_cf_standard_names:"sea_water_pressure"</a></p>
+CF Standard Names are primarily provided by the `cf_standard_names` field.  An example query is below:
+<a href='https://data.ioos.us/dataset?q=cf_standard_names:"sea_water_pressure"'>https://data.ioos.us/dataset?q=cf_standard_names:"sea_water_pressure"</a></p>
+
 <p>
 GCMD keywords work somewhat differently and are organized by hierarchy
 For example a query of <a href='https://data.ioos.us/dataset?q=gcmd_keywords:"Earth Science > Oceans > Ocean Chemistry > Chlorophyll"'>https://data.ioos.us/dataset?q=gcmd_keywords:"Earth Science &gt; Oceans &gt; Ocean Chemistry &gt; Chlorophyll"</a>

--- a/ckanext/ioos_theme/templates/home/snippets/about_text.html
+++ b/ckanext/ioos_theme/templates/home/snippets/about_text.html
@@ -104,6 +104,9 @@ If you want to search for a suffix with GCMD keywords, you will need to use
 a wildcard search:
 <a href='https://data.ioos.us/dataset?q=gcmd_keywords:*Water\ Temperature'><code>*Water\ Temperature'</code></a>
 Note here the use of the escaped space per the Lucene query syntax.
+
+<p>An example request to the CKAN API to query both GCMD Keywords starting with a value of "EARTH SCIENCE &gt; OCEANS &gt; OCEAN SCIENCE" and a CF standard name of "sea_water_electrical_conductivity" using <a href="https://curl.haxx.se/">cURL</a> is below</p>
+<pre><code>curl 'https://data.ioos.us/api/3/action/package_search?fq=gcmd_keywords:"EARTH+SCIENCE+&gt;+OCEANS+&gt;+OCEAN+TEMPERATURE"+cf_standard_names:"sea_water_electrical_conductivity"'</code></pre>
 </p>
 
 <br>


### PR DESCRIPTION
Changes references of `extras_cf_standard_names` to `cf_standard_names` in about page.

Adds cURL example against CKAN API to filter against `gcmd_keywords` and `cf_standard_names`

Addresses #213.